### PR TITLE
Override useGraphQL client in options

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -438,14 +438,15 @@ _SSR function that resolves a HTML string suitable for a static page._
 
 A [React hook](https://reactjs.org/docs/hooks-intro) to manage a GraphQL operation in a component.
 
-| Parameter                      | Type                                                              | Description                                                                                                                     |
-| :----------------------------- | :---------------------------------------------------------------- | :------------------------------------------------------------------------------------------------------------------------------ |
-| `options`                      | Object                                                            | Options.                                                                                                                        |
-| `options.fetchOptionsOverride` | [GraphQLFetchOptionsOverride](#type-graphqlfetchoptionsoverride)? | Overrides default [`fetch` options](#type-graphqlfetchoptions) for the GraphQL operation.                                       |
-| `options.loadOnMount`          | boolean? = `true`                                                 | Should the operation load when the component mounts.                                                                            |
-| `options.loadOnReset`          | boolean? = `true`                                                 | Should the operation load when its [GraphQL cache](#graphql-instance-property-cache) [value](#type-graphqlcachevalue) is reset. |
-| `options.resetOnLoad`          | boolean? = `false`                                                | Should all other [GraphQL cache](#graphql-instance-property-cache) reset when the operation loads.                              |
-| `options.operation`            | [GraphQLOperation](#type-graphqloperation)                        | GraphQL operation.                                                                                                              |
+| Parameter                      | Type                                                              | Description                                                                                                                                                             |
+| :----------------------------- | :---------------------------------------------------------------- | :---------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `options`                      | Object                                                            | Options.                                                                                                                                                                |
+| `options.fetchOptionsOverride` | [GraphQLFetchOptionsOverride](#type-graphqlfetchoptionsoverride)? | Overrides default [`fetch` options](#type-graphqlfetchoptions) for the GraphQL operation.                                                                               |
+| `options.loadOnMount`          | boolean? = `true`                                                 | Should the operation load when the component mounts.                                                                                                                    |
+| `options.loadOnReset`          | boolean? = `true`                                                 | Should the operation load when its [GraphQL cache](#graphql-instance-property-cache) [value](#type-graphqlcachevalue) is reset.                                         |
+| `options.resetOnLoad`          | boolean? = `false`                                                | Should all other [GraphQL cache](#graphql-instance-property-cache) reset when the operation loads.                                                                      |
+| `options.operation`            | [GraphQLOperation](#type-graphqloperation)                        | GraphQL operation.                                                                                                                                                      |
+| `options.graphql`              | [GraphQL](#class-graphql)                                         | Optional [GraphQL](#class-graphql) client. If not supplied, `useGraphQL` will attempt to use the value supplied by [`GraphQLContext`](#type-graphqlcontext) `Provider`. |
 
 **Returns:** [GraphQLOperationStatus](#type-graphqloperationstatus) — GraphQL operation status.
 

--- a/src/test/useGraphQL.mjs
+++ b/src/test/useGraphQL.mjs
@@ -130,7 +130,23 @@ t.test('useGraphQL()', async t => {
     })
   })
 
-  await t.test('GraphQL context missing', t => {
+  await t.test('The `graphql` option can be supplied directly.', t => {
+    const graphql = new GraphQL()
+
+    // eslint-disable-next-line require-jsdoc
+    const Component = () => {
+      useGraphQL({ operation: { query: '{ echo }' }, graphql })
+      return null
+    }
+
+    t.doesNotThrow(() => {
+      ReactDOMServer.renderToString(<Component />)
+    })
+
+    t.end()
+  })
+
+  await t.test('The `graphql` option is missing', t => {
     // eslint-disable-next-line require-jsdoc
     const Component = () => {
       useGraphQL({ operation: { query: '{ echo }' } })
@@ -139,12 +155,12 @@ t.test('useGraphQL()', async t => {
 
     t.throws(() => {
       ReactDOMServer.renderToString(<Component />)
-    }, new Error('GraphQL context missing.'))
+    }, new Error('The `graphql` option must be provided or supplied in a GraphQL context.'))
 
     t.end()
   })
 
-  await t.test('GraphQL context not a GraphQL instance', t => {
+  await t.test('The `graphql` option is not a GraphQL instance', t => {
     // eslint-disable-next-line require-jsdoc
     const Component = () => {
       useGraphQL({ operation: { query: '{ echo }' } })
@@ -157,7 +173,7 @@ t.test('useGraphQL()', async t => {
           <Component />
         </GraphQLContext.Provider>
       )
-    }, new Error('GraphQL context must be a GraphQL instance.'))
+    }, new Error('The `graphql` option must be a GraphQL instance.'))
 
     t.end()
   })

--- a/src/universal/useGraphQL.mjs
+++ b/src/universal/useGraphQL.mjs
@@ -15,8 +15,8 @@ import { hashObject } from './hashObject'
  * @param {boolean} [options.loadOnReset=true] Should the operation load when its [GraphQL cache]{@link GraphQL#cache} [value]{@link GraphQLCacheValue} is reset.
  * @param {boolean} [options.resetOnLoad=false] Should all other [GraphQL cache]{@link GraphQL#cache} reset when the operation loads.
  * @param {GraphQLOperation} options.operation GraphQL operation.
+ * @param {GraphQL} options.graphql Optional GraphQL server. If not supplied, `useGraphQL` will attempt to use the value supplied by [`GraphQLContext`]{@link GraphQLContext} `Provider`.
  * @returns {GraphQLOperationStatus} GraphQL operation status.
- * @see [`GraphQLContext`]{@link GraphQLContext} `Provider`; required for [`useGraphQL`]{@link useGraphQL} to work.
  * @example <caption>A component that displays a Pokémon image.</caption>
  * ```jsx
  * import { useGraphQL } from 'graphql-react'
@@ -46,13 +46,18 @@ export const useGraphQL = ({
   loadOnMount = true,
   loadOnReset = true,
   resetOnLoad = false,
-  operation
+  operation,
+  graphql
 }) => {
-  const graphql = react.useContext(GraphQLContext)
+  const context = react.useContext(GraphQLContext)
+  graphql = graphql || context
+
   if (typeof graphql === 'undefined')
-    throw new Error('GraphQL context missing.')
+    throw new Error(
+      'The `graphql` option must be provided or supplied in a GraphQL context.'
+    )
   if (!(graphql instanceof GraphQL))
-    throw new Error('GraphQL context must be a GraphQL instance.')
+    throw new Error('The `graphql` option must be a GraphQL instance.')
 
   const fetchOptions = graphqlFetchOptions(operation)
   if (fetchOptionsOverride) fetchOptionsOverride(fetchOptions)

--- a/src/universal/useGraphQL.mjs
+++ b/src/universal/useGraphQL.mjs
@@ -15,7 +15,7 @@ import { hashObject } from './hashObject'
  * @param {boolean} [options.loadOnReset=true] Should the operation load when its [GraphQL cache]{@link GraphQL#cache} [value]{@link GraphQLCacheValue} is reset.
  * @param {boolean} [options.resetOnLoad=false] Should all other [GraphQL cache]{@link GraphQL#cache} reset when the operation loads.
  * @param {GraphQLOperation} options.operation GraphQL operation.
- * @param {GraphQL} options.graphql Optional GraphQL server. If not supplied, `useGraphQL` will attempt to use the value supplied by [`GraphQLContext`]{@link GraphQLContext} `Provider`.
+ * @param {GraphQL} options.graphql Optional [GraphQL]{@link GraphQL} client. If not supplied, `useGraphQL` will attempt to use the value supplied by [`GraphQLContext`]{@link GraphQLContext} `Provider`.
  * @returns {GraphQLOperationStatus} GraphQL operation status.
  * @example <caption>A component that displays a Pokémon image.</caption>
  * ```jsx


### PR DESCRIPTION
Currently, the `graphql` param is supplied by context, but all others are required on the component itself. This makes it quite challenging to wrap `useGraphQL` in a custom hook that stores defaults for the other options in context.

I would prefer the ability to specify defaults for all options using `GraphQLContext.Provider`, but that's easily done in userland with this change.